### PR TITLE
Update gophermap2gemini.awk: Fix anymous telnet/tn3270 links.

### DIFF
--- a/bin/gophermap2gemini.awk
+++ b/bin/gophermap2gemini.awk
@@ -58,14 +58,22 @@ BEGIN {
 		}
 		url = path
 		printf("=> %s %s\n", url, label)
-	} else if ( type == "T") {
-		# telnet links
-		if (isFenced)  {
-			# end fences for links
-			print "```"
-			isFenced=0
-		}
-		printf("=> telnet://%s:%s/%s%s %s\n", server, port, type, path, label)
+        } else if ( type == "T") {
+                # ANONYMOUS TN3270 links
+                if (isFenced)  {
+                        # end fences for links
+                        print "```"
+                        isFenced=0
+                }
+                printf("=> telnet://%s:%s/%s %s\n", server, port, path, label)
+        } else if ( type == "8") {
+                # ANONYMOUS telnet links
+                if (isFenced)  {
+                        # end fences for links
+                        print "```"
+                        isFenced=0
+                }
+                printf("=> telnet://%s:%s/%s %s\n", server, port, path, label)
 	} else {
 		# any other gopher type
 		if (isFenced)  {


### PR DESCRIPTION
TN3270 links were generated like:
telnet://somewhere:port/T
the /T is from the gophertype and is not used to generate the telnet URL

Added gophertype 8 (telnet)

Note: Both of these work for anonymous telnet/tn3270. They do not work if a login was specified.